### PR TITLE
prevent Package natbib Error: Bibliography not compatible with author…

### DIFF
--- a/pucrs-ppgcc.cls
+++ b/pucrs-ppgcc.cls
@@ -84,7 +84,7 @@ e-mail <rfbpiccoli at gmail dot com>^^J
 %\LoadClass[12pt,onecolumn,twoside,titlepage,a4paper,openright,final]{report}[2007/10/19]
 \LoadClass[12pt,onecolumn,titlepage,a4paper,openright,final]{report}[2007/10/19]
 
-\RequirePackage[round,sectionbib]{natbib}
+\RequirePackage[round,sectionbib,numbers]{natbib}
 \RequirePackage[T1]{fontenc}[2005/09/27]
 \RequirePackage[utf8]{inputenc}[2008/03/30]
 \RequirePackage[english,brazil]{babel}[2008/07/06]


### PR DESCRIPTION
this happens when using:
```
    pdflatex exemplo.tex
    bibtex exemplo.aux
    pdflatex exemplo.tex
    pdflatex exemplo.tex
```

On the 3rd and 4rd commands, natbib complains with "Package natbib Error: Bibliography not compatible with author-year citations.", and asks for user interaction.

https://tex.stackexchange.com/a/75015/166499
