### PR TITLE
Alteração do nome da Escola Politécnica quando escrita em inglês

### DIFF
--- a/pucrs-ppgcc.cls
+++ b/pucrs-ppgcc.cls
@@ -253,7 +253,7 @@ e-mail <rfbpiccoli at gmail dot com>^^J
 %}
 \addto\captionsenglish{%
     \renewcommand*{\PP@Uni}{Pontifical Catholic University of Rio Grande do Sul}
-    \renewcommand*{\PP@Fac}{Polytechnic Institute}
+    \renewcommand*{\PP@Fac}{School of Technology}
     \renewcommand*{\PP@Dep}{Computer Science Graduate Program}
     %\edef\PP@undef{not defined}
     \renewcommand*{\tese}{Dissertation}


### PR DESCRIPTION
Olá! Recebi a seguinte solicitação:
"Olhando para as teses e dissertações dos meus alunos para usar o nome correto em Inglês da escola. O template do PPGCC está errado e está colocando como "Polytechnic Institute" mas na página da PUCRS está como "School of Technology". Tem que pedir para o pessoal corrigir."

Fiz a alteração e já atualizei.

Valeu!